### PR TITLE
Historical data fetch fix

### DIFF
--- a/src/main/java/com/angelbroking/smartapi/Routes.java
+++ b/src/main/java/com/angelbroking/smartapi/Routes.java
@@ -43,6 +43,7 @@ public class Routes {
 				put("api.gtt.cancel","/gtt-service/rest/secure/angelbroking/gtt/v1/cancelRule");
 				put("api.gtt.details","/rest/secure/angelbroking/gtt/v1/ruleDetails");
 				put("api.gtt.list","/rest/secure/angelbroking/gtt/v1/ruleList");
+				put("api.candle.data","/rest/secure/angelbroking/historical/v1/getCandleData");
 			}
 		};
 	}


### PR DESCRIPTION
Historical data fetch method getCandleData() not working due to missing "api.candle.data" in routes.
Updated same in Routes file.